### PR TITLE
Rewrite query parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ miette = "7.4.0"
 [dependencies.query-kdl]
 version = "0.1.0"
 path = "crates/query-kdl"
-features = ["eval"]
+features = ["resolve"]
 
 [dependencies.kdl]
 version = "6.1.0"

--- a/crates/query-kdl/Cargo.toml
+++ b/crates/query-kdl/Cargo.toml
@@ -11,4 +11,4 @@ optional = true
 version = "6.1.0"
 
 [features]
-eval = ["kdl"]
+resolve = ["kdl"]

--- a/crates/query-kdl/src/eval/mod.rs
+++ b/crates/query-kdl/src/eval/mod.rs
@@ -1,3 +1,0 @@
-use kdl::{KdlDocument, KdlEntry, KdlNode, KdlValue};
-
-// pub fn eval_document<'a>(query: &'a KdlDocument) -> Vec<>

--- a/crates/query-kdl/src/lexer.rs
+++ b/crates/query-kdl/src/lexer.rs
@@ -7,6 +7,7 @@ pub enum TokenType<'a> {
     Point,
     DoublePoint,
     Star,
+    DoubleStar,
     EnterSquareBracket,
     LeaveSquareBracket,
     EnterCurlyBracket,
@@ -26,6 +27,7 @@ impl<'a> std::fmt::Display for TokenType<'a> {
             TokenType::Point => write!(f, "."),
             TokenType::DoublePoint => write!(f, ".."),
             TokenType::Star => write!(f, "*"),
+            TokenType::DoubleStar => write!(f, "**"),
             TokenType::EnterSquareBracket => write!(f, "["),
             TokenType::LeaveSquareBracket => write!(f, "]"),
             TokenType::EnterCurlyBracket => write!(f, "{{"),
@@ -135,7 +137,13 @@ impl<'a> Lexer<'a> {
                 }
                 Some(_) | None => Point,
             },
-            '*' => Star,
+            '*' => match iter_chars.next() {
+                Some((l, '*')) => {
+                    offset += l;
+                    DoubleStar
+                }
+                Some(_) | None => Star,
+            },
             '=' => Equal,
             '|' => Pipe,
             c => Unknown(&self.input[0..c.len_utf8()]),
@@ -244,12 +252,14 @@ mod tests {
     }
     #[test]
     fn token_relatives() {
-        let mut lexer = Lexer::from("/./..//*");
+        let mut lexer = Lexer::from("/./../**/*");
         assert_eq!(lexer.next(), Some(TokenType::Slash));
         assert_eq!(lexer.next(), Some(TokenType::Point));
         assert_eq!(lexer.next(), Some(TokenType::Slash));
         assert_eq!(lexer.next(), Some(TokenType::DoublePoint));
-        assert_eq!(lexer.next(), Some(TokenType::DoubleSlash));
+        assert_eq!(lexer.next(), Some(TokenType::Slash));
+        assert_eq!(lexer.next(), Some(TokenType::DoubleStar));
+        assert_eq!(lexer.next(), Some(TokenType::Slash));
         assert_eq!(lexer.next(), Some(TokenType::Star));
         assert_eq!(lexer.next(), None);
     }

--- a/crates/query-kdl/src/lib.rs
+++ b/crates/query-kdl/src/lib.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "eval")]
-pub mod eval;
 pub mod lexer;
 pub mod parser;
+#[cfg(feature = "resolve")]
+pub mod resolve;
 pub mod util;

--- a/crates/query-kdl/src/parser.rs
+++ b/crates/query-kdl/src/parser.rs
@@ -111,14 +111,14 @@ impl<'a> NodeBuilder<'a> {
     fn new() -> Self {
         Self(None)
     }
-    fn set_node(&mut self, node: SelectorKind<'a>) -> std::result::Result<(), ()> {
+    fn set_node(&mut self, node: SelectorKind<'a>) -> Result<'a, ()> {
         if self.0.is_some() {
-            return Err(());
+            todo!("error node already defined");
         }
         self.0.insert(Selector::from(node));
         Ok(())
     }
-    fn set_entries(&mut self, entries: Entries<'a>) -> std::result::Result<(), ()> {
+    fn set_entries(&mut self, entries: Entries<'a>) -> Result<'a, ()> {
         let Some(node) = self.0.as_mut() else {
             todo!("error missing node");
         };
@@ -128,7 +128,7 @@ impl<'a> NodeBuilder<'a> {
         node.entries.insert(entries);
         Ok(())
     }
-    fn pop(&mut self) -> std::result::Result<Selector<'a>, ()> {
+    fn pop(&mut self) -> Result<'a, Selector<'a>> {
         self.0.take().ok_or_else(|| todo!("error missing node"))
     }
 }
@@ -168,7 +168,6 @@ impl<'a> Path<'a> {
         if let Some(node) = node_builder.0 {
             nodes.push(node);
         }
-
         return Ok(Self { nodes });
     }
     fn parse_range(lexer: &mut impl Iterator<Item = TokenType<'a>>) -> Result<'a, Range> {

--- a/crates/query-kdl/src/parser.rs
+++ b/crates/query-kdl/src/parser.rs
@@ -119,7 +119,7 @@ impl<'a> NodeBuilder<'a> {
     }
     fn set_entries(&mut self, entries: Entries<'a>) -> Result<'a, ()> {
         let Some(node) = self.0.as_mut() else {
-            return Err(ParseError::MIssingNode);
+            return Err(ParseError::MissingNode);
         };
         if node.entries.is_some() {
             return Err(ParseError::EntriesAlreadyDefined);

--- a/crates/query-kdl/src/parser.rs
+++ b/crates/query-kdl/src/parser.rs
@@ -19,15 +19,15 @@ pub struct Selector<'a> {
 
 impl<'a> Display for Selector<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.node);
+        write!(f, "{}", self.node)?;
         if let Some(entries) = &self.entries {
-            write!(f, "{entries}");
+            write!(f, "{entries}")?;
         }
         Ok(())
     }
 }
 
-impl<'a> From<SelectorKind<'a>> for Selector {
+impl<'a> From<SelectorKind<'a>> for Selector<'a> {
     fn from(node: SelectorKind<'a>) -> Self {
         Self {
             node,
@@ -115,7 +115,7 @@ impl<'a> NodeBuilder<'a> {
         if self.0.is_some() {
             todo!("error node already defined");
         }
-        self.0.insert(Selector::from(node));
+        let _ = self.0.insert(Selector::from(node));
         Ok(())
     }
     fn set_entries(&mut self, entries: Entries<'a>) -> Result<'a, ()> {
@@ -125,7 +125,7 @@ impl<'a> NodeBuilder<'a> {
         if node.entries.is_some() {
             todo!("error entries already defined");
         }
-        node.entries.insert(entries);
+        let _ = node.entries.insert(entries);
         Ok(())
     }
     fn pop(&mut self) -> Result<'a, Selector<'a>> {

--- a/crates/query-kdl/src/parser.rs
+++ b/crates/query-kdl/src/parser.rs
@@ -113,17 +113,17 @@ impl<'a> NodeBuilder<'a> {
     }
     fn set_node(&mut self, node: SelectorKind<'a>) -> Result<'a, ()> {
         if self.0.is_some() {
-            todo!("error node already defined");
+            return Err(ParseError::NodeAlreadyDefined);
         }
         let _ = self.0.insert(Selector::from(node));
         Ok(())
     }
     fn set_entries(&mut self, entries: Entries<'a>) -> Result<'a, ()> {
         let Some(node) = self.0.as_mut() else {
-            todo!("error missing node");
+            return Err(ParseError::MIssingNode);
         };
         if node.entries.is_some() {
-            todo!("error entries already defined");
+            return Err(ParseError::EntriesAlreadyDefined);
         }
         let _ = node.entries.insert(entries);
         Ok(())

--- a/crates/query-kdl/src/parser.rs
+++ b/crates/query-kdl/src/parser.rs
@@ -97,7 +97,6 @@ pub struct Path<'a> {
 
 impl<'a> Display for Path<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "/")?;
         for node in &self.nodes {
             write!(f, "{node}/")?;
         }

--- a/crates/query-kdl/src/parser/error.rs
+++ b/crates/query-kdl/src/parser/error.rs
@@ -53,7 +53,7 @@ pub enum ParseError<'a> {
     #[error("expected a node, but got something else")]
     NotANode,
     #[error("missing node before entries")]
-    MIssingNode,
+    MissingNode,
     #[error("A node is already defined before")]
     NodeAlreadyDefined,
     #[error("The entries is already defined before")]

--- a/crates/query-kdl/src/parser/error.rs
+++ b/crates/query-kdl/src/parser/error.rs
@@ -40,8 +40,6 @@ pub enum ParseError<'a> {
     UnexpectedToken(TokenType<'a>),
     #[error("The string \"{0}\" is malformed: {1}")]
     MalformedString(&'a str, ParseStringError),
-    #[error("malformed number: {0}")]
-    MalformedNumber(&'a str),
     #[error("double equal in entries")]
     DoubleEqual,
     #[error("missing entry value after an equal")]
@@ -54,6 +52,12 @@ pub enum ParseError<'a> {
     EntriesOnMarker,
     #[error("expected a node, but got something else")]
     NotANode,
+    #[error("missing node before entries")]
+    MIssingNode,
+    #[error("A node is already defined before")]
+    NodeAlreadyDefined,
+    #[error("The entries is already defined before")]
+    EntriesAlreadyDefined,
     #[error("expected an integer number, got: {0}")]
     RangeExpectingInteger(Value<'a>),
     #[error("The range is empty")]

--- a/crates/query-kdl/src/parser/tests.rs
+++ b/crates/query-kdl/src/parser/tests.rs
@@ -285,29 +285,46 @@ fn path_ident_parents() {
 }
 
 #[test]
-fn node_with_entries() {
+fn nodes_with_entries() {
     assert_eq!(
-        Path::parse(r#"..[1 2 3]/node1"#),
+        Path::parse(r#"..[1]/node1[2]/*[3]/**[4]/{1..2}[5]"#),
         Ok(Path {
             nodes: vec![
                 Selector {
                     node: SelectorKind::Parent,
-                    entries: Some(Entries::from(vec![
-                        EntryKind::Argument {
-                            position: 0,
-                            value: Value::Integer(1)
-                        },
-                        EntryKind::Argument {
-                            position: 1,
-                            value: Value::Integer(2)
-                        },
-                        EntryKind::Argument {
-                            position: 2,
-                            value: Value::Integer(3)
-                        },
-                    ]))
+                    entries: Some(Entries::from(vec![EntryKind::Argument {
+                        position: 0,
+                        value: Value::Integer(1)
+                    },]))
                 },
-                Selector::from(SelectorKind::Named(Cow::Borrowed("node1")))
+                Selector {
+                    node: SelectorKind::Named(Cow::Borrowed("node1")),
+                    entries: Some(Entries::from(vec![EntryKind::Argument {
+                        position: 0,
+                        value: Value::Integer(2)
+                    },]))
+                },
+                Selector {
+                    node: SelectorKind::Any,
+                    entries: Some(Entries::from(vec![EntryKind::Argument {
+                        position: 0,
+                        value: Value::Integer(3)
+                    },]))
+                },
+                Selector {
+                    node: SelectorKind::Anywhere,
+                    entries: Some(Entries::from(vec![EntryKind::Argument {
+                        position: 0,
+                        value: Value::Integer(4)
+                    },]))
+                },
+                Selector {
+                    node: SelectorKind::Ranged(crate::parser::Range::Both(1, 2)),
+                    entries: Some(Entries::from(vec![EntryKind::Argument {
+                        position: 0,
+                        value: Value::Integer(5)
+                    },]))
+                },
             ]
         })
     );

--- a/crates/query-kdl/src/parser/tests.rs
+++ b/crates/query-kdl/src/parser/tests.rs
@@ -3,13 +3,12 @@ use std::borrow::Cow;
 use crate::{
     lexer::{Lexer, TokenType},
     parser::{
-        entries::EntryKind, error::ParseStringError, string, Entries, ParseError, Path, Selector,
-        Value,
+        entries::EntryKind, error::ParseStringError, string, Entries, Node, ParseError, Path, Value,
     },
     util::hashmap,
 };
 
-use super::SelectorKind;
+use super::NodeKind;
 #[test]
 fn parser_strings() {
     fn test_string(input: &str, output: Result<&str, ParseError>) {
@@ -194,9 +193,7 @@ fn path_named_one() {
     assert_eq!(
         Path::parse("node_name"),
         Ok(Path {
-            nodes: vec![Selector::from(SelectorKind::Named(Cow::Borrowed(
-                "node_name"
-            )))]
+            nodes: vec![Node::from(NodeKind::Named(Cow::Borrowed("node_name")))]
         })
     );
 }
@@ -207,8 +204,8 @@ fn path_named_multi() {
         Path::parse("node1/node2"),
         Ok(Path {
             nodes: vec![
-                Selector::from(SelectorKind::Named(Cow::Borrowed("node1"))),
-                Selector::from(SelectorKind::Named(Cow::Borrowed("node2"))),
+                Node::from(NodeKind::Named(Cow::Borrowed("node1"))),
+                Node::from(NodeKind::Named(Cow::Borrowed("node2"))),
             ]
         })
     );
@@ -220,8 +217,8 @@ fn path_named_strings() {
         Path::parse(r#""node 1"/"node 2""#),
         Ok(Path {
             nodes: vec![
-                Selector::from(SelectorKind::Named(Cow::Borrowed("node 1"))),
-                Selector::from(SelectorKind::Named(Cow::Borrowed("node 2"))),
+                Node::from(NodeKind::Named(Cow::Borrowed("node 1"))),
+                Node::from(NodeKind::Named(Cow::Borrowed("node 2"))),
             ]
         })
     );
@@ -231,16 +228,16 @@ fn path_named_strings() {
 //     assert_eq!(
 //         Path::parse(r#"/node1"#),
 //         Ok(Path {
-//             nodes: vec![Selector::from(SelectorKind::Root(, Selector::from(SelectorKind::Named((Cow::Borrowed("node1"))]
+//             nodes: vec![Node::from(NodeKind::Root(, Node::from(NodeKind::Named((Cow::Borrowed("node1"))]
 //         })
 //     );
 //     assert_eq!(
 //         Path::parse(r#"/node1/node2"#),
 //         Ok(Path {
 //             nodes: vec![
-//                 Selector::from(SelectorKind::Root(,
-//                 Selector::from(SelectorKind::Named((Cow::Borrowed("node1")),
-//                 Selector::from(SelectorKind::Named((Cow::Borrowed("node2"))
+//                 Node::from(NodeKind::Root(,
+//                 Node::from(NodeKind::Named((Cow::Borrowed("node1")),
+//                 Node::from(NodeKind::Named((Cow::Borrowed("node2"))
 //             ]
 //         })
 //     );
@@ -252,8 +249,8 @@ fn path_ident_anywhere() {
         Path::parse(r#"**/node1"#),
         Ok(Path {
             nodes: vec![
-                Selector::from(SelectorKind::Anywhere),
-                Selector::from(SelectorKind::Named(Cow::Borrowed("node1")))
+                Node::from(NodeKind::Anywhere),
+                Node::from(NodeKind::Named(Cow::Borrowed("node1")))
             ]
         })
     );
@@ -265,8 +262,8 @@ fn path_ident_any() {
         Path::parse(r#"*/node1"#),
         Ok(Path {
             nodes: vec![
-                Selector::from(SelectorKind::Any),
-                Selector::from(SelectorKind::Named(Cow::Borrowed("node1")))
+                Node::from(NodeKind::Any),
+                Node::from(NodeKind::Named(Cow::Borrowed("node1")))
             ]
         })
     );
@@ -277,8 +274,8 @@ fn path_ident_parents() {
         Path::parse(r#"../node1"#),
         Ok(Path {
             nodes: vec![
-                Selector::from(SelectorKind::Parent),
-                Selector::from(SelectorKind::Named(Cow::Borrowed("node1")))
+                Node::from(NodeKind::Parent),
+                Node::from(NodeKind::Named(Cow::Borrowed("node1")))
             ]
         })
     );
@@ -290,36 +287,36 @@ fn nodes_with_entries() {
         Path::parse(r#"..[1]/node1[2]/*[3]/**[4]/{1..2}[5]"#),
         Ok(Path {
             nodes: vec![
-                Selector {
-                    node: SelectorKind::Parent,
+                Node {
+                    node: NodeKind::Parent,
                     entries: Some(Entries::from(vec![EntryKind::Argument {
                         position: 0,
                         value: Value::Integer(1)
                     },]))
                 },
-                Selector {
-                    node: SelectorKind::Named(Cow::Borrowed("node1")),
+                Node {
+                    node: NodeKind::Named(Cow::Borrowed("node1")),
                     entries: Some(Entries::from(vec![EntryKind::Argument {
                         position: 0,
                         value: Value::Integer(2)
                     },]))
                 },
-                Selector {
-                    node: SelectorKind::Any,
+                Node {
+                    node: NodeKind::Any,
                     entries: Some(Entries::from(vec![EntryKind::Argument {
                         position: 0,
                         value: Value::Integer(3)
                     },]))
                 },
-                Selector {
-                    node: SelectorKind::Anywhere,
+                Node {
+                    node: NodeKind::Anywhere,
                     entries: Some(Entries::from(vec![EntryKind::Argument {
                         position: 0,
                         value: Value::Integer(4)
                     },]))
                 },
-                Selector {
-                    node: SelectorKind::Ranged(crate::parser::Range::Both(1, 2)),
+                Node {
+                    node: NodeKind::Ranged(crate::parser::Range::Both(1, 2)),
                     entries: Some(Entries::from(vec![EntryKind::Argument {
                         position: 0,
                         value: Value::Integer(5)
@@ -379,25 +376,16 @@ fn strings() {
 #[test]
 fn ranges() {
     use super::Range;
-    use SelectorKind::Ranged;
+    use NodeKind::Ranged;
     let parse = |s| Path::parse(s).map(|v| v.nodes);
-    assert_eq!(
-        parse("{1}"),
-        Ok(vec![Selector::from(Ranged(Range::One(1)))])
-    );
-    assert_eq!(
-        parse("{..2}"),
-        Ok(vec![Selector::from(Ranged(Range::To(2)))])
-    );
-    assert_eq!(
-        parse("{1..}"),
-        Ok(vec![Selector::from(Ranged(Range::From(1)))])
-    );
+    assert_eq!(parse("{1}"), Ok(vec![Node::from(Ranged(Range::One(1)))]));
+    assert_eq!(parse("{..2}"), Ok(vec![Node::from(Ranged(Range::To(2)))]));
+    assert_eq!(parse("{1..}"), Ok(vec![Node::from(Ranged(Range::From(1)))]));
     assert_eq!(
         parse("{1..2}"),
-        Ok(vec![Selector::from(Ranged(Range::Both(1, 2)))])
+        Ok(vec![Node::from(Ranged(Range::Both(1, 2)))])
     );
-    assert_eq!(parse("{..}"), Ok(vec![Selector::from(Ranged(Range::All))]));
+    assert_eq!(parse("{..}"), Ok(vec![Node::from(Ranged(Range::All))]));
     assert_eq!(
         parse("{abc..}"),
         Err(ParseError::RangeExpectingInteger(Value::Str(

--- a/crates/query-kdl/src/parser/tests.rs
+++ b/crates/query-kdl/src/parser/tests.rs
@@ -325,6 +325,24 @@ fn nodes_with_entries() {
             ]
         })
     );
+
+    assert_eq!(
+        Path::parse("node1[1][2]"),
+        Err(ParseError::EntriesAlreadyDefined)
+    );
+    assert_eq!(
+        Path::parse("node1 node2"),
+        Err(ParseError::NodeAlreadyDefined)
+    );
+    assert_eq!(
+        Path::parse("node1 node2 [1]"),
+        Err(ParseError::NodeAlreadyDefined)
+    );
+    assert_eq!(
+        Path::parse("node1 [1] node2"),
+        Err(ParseError::NodeAlreadyDefined)
+    );
+    assert_eq!(Path::parse("node1/[1]"), Err(ParseError::MissingNode));
 }
 #[test]
 fn alphanum() {

--- a/crates/query-kdl/src/resolve/mod.rs
+++ b/crates/query-kdl/src/resolve/mod.rs
@@ -1,0 +1,3 @@
+use kdl::{KdlDocument, KdlEntry, KdlNode, KdlValue};
+
+// pub fn resolve_document<'a>(query: &'a KdlDocument) -> Vec<>


### PR DESCRIPTION
The old rules for the path were shitty, I rewrote the ground rules (`Path::parse` essentially) to get a better shape of the path less error prone